### PR TITLE
feat: add prefilter for sentence-level checks

### DIFF
--- a/src/lib/server/editors/CompressionEditor.ts
+++ b/src/lib/server/editors/CompressionEditor.ts
@@ -28,7 +28,12 @@ export class CompressionEditor extends PromptEditor {
 	}
 
 	async canBeApplied(prompt: Tables<'prompts'>, llm: LLM) {
-		return await filterSentences(prompt.prompt, llm, [canBeSimplifiedPrompt]);
+		return await filterSentences(
+			prompt.prompt,
+			llm,
+			[canBeSimplifiedPrompt],
+			(sentence) => sentence.split(' ').length > 15
+		);
 	}
 
 	async rewritePrompt(

--- a/src/lib/server/editors/NoNegationEditor.ts
+++ b/src/lib/server/editors/NoNegationEditor.ts
@@ -53,10 +53,12 @@ export class NoNegationEditor extends PromptEditor {
 	}
 
 	async canBeApplied(prompt: Tables<'prompts'>, llm: LLM) {
-		return await filterSentences(prompt.prompt, llm, [
-			instructionClassifierPrompt,
-			negationClassifierPrompt
-		]);
+		return await filterSentences(
+			prompt.prompt,
+			llm,
+			[instructionClassifierPrompt, negationClassifierPrompt],
+			(sentence) => ['not', "n't", 'no', 'never'].some((negation) => sentence.includes(negation))
+		);
 	}
 
 	async rewritePrompt(

--- a/src/lib/server/editors/SingleInstructionEditor.ts
+++ b/src/lib/server/editors/SingleInstructionEditor.ts
@@ -59,10 +59,12 @@ export class SingleInstructionEditor extends PromptEditor {
 	}
 
 	async canBeApplied(prompt: Tables<'prompts'>, llm: LLM) {
-		return await filterSentences(prompt.prompt, llm, [
-			instructionPrompt,
-			multipleInstructionPrompt
-		]);
+		return await filterSentences(
+			prompt.prompt,
+			llm,
+			[instructionPrompt, multipleInstructionPrompt],
+			(sentence) => sentence.includes(' and ') || sentence.includes(' or ')
+		);
 	}
 
 	async rewritePrompt(

--- a/src/lib/server/editors/util.ts
+++ b/src/lib/server/editors/util.ts
@@ -5,13 +5,15 @@ import type { LLM } from '../llms/llm';
  * @param prompt target propmt to be filtered
  * @param llm language model to be used
  * @param filterPrompts filter prompts to be used
+ * @param prefilter optional prefilter to be used, checks if the sentence should be filtered
  * @returns the indices of the sentences in the given prompt that match any of the filter prompts
  *     or null if no sentences match the filter prompts
  */
 export async function filterSentences(
 	prompt: string,
 	llm: LLM,
-	filterPrompts: string[]
+	filterPrompts: string[],
+	prefilter: (sentence: string) => boolean
 ): Promise<number[][] | null> {
 	const segmenter = new Intl.Segmenter('en', {
 		granularity: 'sentence'
@@ -27,6 +29,8 @@ export async function filterSentences(
 			candidateSentence: false
 		};
 	});
+
+	phrases = phrases.filter((p) => prefilter(p.phrase));
 
 	for (const filterPrompt of filterPrompts) {
 		phrases = await Promise.all(


### PR DESCRIPTION
This is needed as otherwise we're instantly running into rate limits for longer prompts.