### PR TITLE
refactor: move selected edit suggestion to other suggestions

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -98,6 +98,7 @@ export async function acceptSuggestion(
 	prompt: Tables<'prompts'>,
 	userInput: string | undefined
 ): Promise<Tables<'prompts'>> {
+	console.log(suggestion);
 	const res = await fetch(`/api/editor/suggestions/accept`, {
 		method: 'POST',
 		headers: {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -98,7 +98,6 @@ export async function acceptSuggestion(
 	prompt: Tables<'prompts'>,
 	userInput: string | undefined
 ): Promise<Tables<'prompts'>> {
-	console.log(suggestion);
 	const res = await fetch(`/api/editor/suggestions/accept`, {
 		method: 'POST',
 		headers: {

--- a/src/lib/components/prompt/PromptBar.svelte
+++ b/src/lib/components/prompt/PromptBar.svelte
@@ -113,6 +113,7 @@
 			{prompt}
 			{hoveredSuggestion}
 			{setPrompt}
+			{suggestions}
 			bind:selectedSpan
 			bind:promptMaximized
 			bind:suggestionApplied

--- a/src/lib/components/prompt/PromptBar.svelte
+++ b/src/lib/components/prompt/PromptBar.svelte
@@ -24,6 +24,7 @@
 	let showOptions = $state(false);
 	let suggestionApplied = $state(-1);
 	let hoveredSuggestion: Tables<'suggestions'> | null = $state(null);
+	let selectedSpan = $state<{ start: number; end: number } | undefined>(undefined);
 
 	function loadPrompt(id: number | null) {
 		if (id === null) goto(`/project/${projectId}`);
@@ -112,7 +113,7 @@
 			{prompt}
 			{hoveredSuggestion}
 			{setPrompt}
-			{editPrompt}
+			bind:selectedSpan
 			bind:promptMaximized
 			bind:suggestionApplied
 			bind:editedPrompt
@@ -124,6 +125,7 @@
 		{editPrompt}
 		{suggestions}
 		{suggestionApplied}
+		bind:selectedSpan
 		setHoveredSuggestion={(suggestion) => (hoveredSuggestion = suggestion)}
 	/>
 </div>

--- a/src/lib/components/prompt/PromptEditor.svelte
+++ b/src/lib/components/prompt/PromptEditor.svelte
@@ -30,10 +30,6 @@
 	let promptWasEdited = $derived(
 		JSON.stringify(prompt) === JSON.stringify(editedPrompt) ? false : true
 	);
-	$inspect('prompt: ', JSON.stringify(prompt));
-	$inspect('edited: ', JSON.stringify(editedPrompt));
-	$inspect('edited prompt: ', JSON.stringify(editedPrompt.prompt));
-	$inspect('was edited: ', promptWasEdited);
 
 	let promptEditor: HTMLTextAreaElement | undefined = $state(undefined);
 	let promptCopied = $state(false);
@@ -83,7 +79,6 @@
 			onselect={getSelection}
 			onmousedown={() => (selectedSpan = undefined)}
 			onkeydown={(e) => {
-				console.log(e);
 				selectedSpan = undefined;
 				suggestionApplied = -1;
 				if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {

--- a/src/lib/components/prompt/PromptEditor.svelte
+++ b/src/lib/components/prompt/PromptEditor.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
 	import { afterNavigate } from '$app/navigation';
 	import autosize from '$lib/autosize';
-	import { clickOutside } from '$lib/clickOutside';
 	import Button from '$lib/components/ui/Button.svelte';
 	import type { Tables } from '$lib/supabase';
 	import { Check, Copy, Expand, Save, Undo2 } from 'lucide-svelte';
 	import { fade } from 'svelte/transition';
-	import RewriteBox from './RewriteBox.svelte';
 	import SuggestionOverlay from './SuggestionOverlay.svelte';
 
 	let {
@@ -15,16 +13,16 @@
 		prompt,
 		promptMaximized = false,
 		setPrompt,
-		editPrompt,
-		suggestionApplied
+		suggestionApplied,
+		selectedSpan
 	} = $props<{
 		editedPrompt: Tables<'prompts'>;
 		hoveredSuggestion: Tables<'suggestions'> | null;
 		prompt: Tables<'prompts'>;
 		promptMaximized: boolean;
 		setPrompt: () => void;
-		editPrompt: (newPrompt: Tables<'prompts'>, suggestionId: number) => void;
 		suggestionApplied: number;
+		selectedSpan: { start: number; end: number } | undefined;
 	}>();
 
 	let promptWasEdited = $derived(
@@ -34,7 +32,6 @@
 	let promptEditor: HTMLTextAreaElement | undefined = $state(undefined);
 	let promptCopied = $state(false);
 	let promptHovered = $state(false);
-	let selectedSpan = $state<{ start: number; end: number } | undefined>(undefined);
 	let promptSubmitted = $state(false);
 
 	function copyPrompt() {
@@ -66,13 +63,9 @@
 	class="relative flex min-h-24 grow cursor-text flex-col text-left"
 	onmouseenter={() => (promptHovered = true)}
 	onmouseleave={() => (promptHovered = false)}
-	use:clickOutside={() => (selectedSpan = undefined)}
 	role="button"
 	tabindex="0"
 >
-	{#if selectedSpan}
-		<RewriteBox bind:selectedSpan {prompt} {editPrompt} />
-	{/if}
 	<div class="relative min-h-24 grow overflow-y-auto rounded border shadow">
 		<textarea
 			class="relative h-full min-h-24 w-full border-none bg-white py-2 pl-2 pr-6 text-sm outline-none"

--- a/src/lib/components/prompt/PromptEditor.svelte
+++ b/src/lib/components/prompt/PromptEditor.svelte
@@ -30,6 +30,10 @@
 	let promptWasEdited = $derived(
 		JSON.stringify(prompt) === JSON.stringify(editedPrompt) ? false : true
 	);
+	$inspect('prompt: ', JSON.stringify(prompt));
+	$inspect('edited: ', JSON.stringify(editedPrompt));
+	$inspect('edited prompt: ', JSON.stringify(editedPrompt.prompt));
+	$inspect('was edited: ', promptWasEdited);
 
 	let promptEditor: HTMLTextAreaElement | undefined = $state(undefined);
 	let promptCopied = $state(false);
@@ -79,6 +83,7 @@
 			onselect={getSelection}
 			onmousedown={() => (selectedSpan = undefined)}
 			onkeydown={(e) => {
+				console.log(e);
 				selectedSpan = undefined;
 				suggestionApplied = -1;
 				if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
@@ -134,7 +139,10 @@
 	{#if promptWasEdited && !promptSubmitted}
 		<Button
 			onclick={() => {
-				editedPrompt = { ...prompt };
+				editedPrompt.prompt = prompt.prompt;
+				editedPrompt.model = prompt.model;
+				editedPrompt.responseFormat = prompt.responseFormat;
+				editedPrompt.temperature = prompt.temperature;
 				suggestionApplied = -1;
 			}}
 			classNames="text-gray-active"

--- a/src/lib/components/prompt/PromptEditor.svelte
+++ b/src/lib/components/prompt/PromptEditor.svelte
@@ -14,7 +14,8 @@
 		promptMaximized = false,
 		setPrompt,
 		suggestionApplied,
-		selectedSpan
+		selectedSpan,
+		suggestions
 	} = $props<{
 		editedPrompt: Tables<'prompts'>;
 		hoveredSuggestion: Tables<'suggestions'> | null;
@@ -23,6 +24,7 @@
 		setPrompt: () => void;
 		suggestionApplied: number;
 		selectedSpan: { start: number; end: number } | undefined;
+		suggestions: Promise<Tables<'suggestions'>[] | undefined>;
 	}>();
 
 	let promptWasEdited = $derived(
@@ -68,7 +70,7 @@
 >
 	<div class="relative min-h-24 grow overflow-y-auto rounded border shadow">
 		<textarea
-			class="relative h-full min-h-24 w-full border-none bg-white py-2 pl-2 pr-6 text-sm outline-none"
+			class="relative h-full min-h-24 w-full border-none bg-white py-2 pl-2 pr-6 text-sm outline-none selection:bg-transparent"
 			bind:this={promptEditor}
 			bind:value={editedPrompt.prompt}
 			use:autosize
@@ -82,15 +84,14 @@
 				}
 			}}
 		/>
-		{#if suggestionApplied !== -1 || (!promptWasEdited && hoveredSuggestion && hoveredSuggestion.target_spans) || selectedSpan}
-			<SuggestionOverlay
-				{prompt}
-				{hoveredSuggestion}
-				{suggestionApplied}
-				{editedPrompt}
-				{selectedSpan}
-			/>
-		{/if}
+		<SuggestionOverlay
+			{prompt}
+			{hoveredSuggestion}
+			{suggestionApplied}
+			{editedPrompt}
+			bind:selectedSpan
+			{suggestions}
+		/>
 	</div>
 	<div class="absolute right-1 top-1 flex flex-col gap-1">
 		<button

--- a/src/lib/components/prompt/PromptEditor.svelte
+++ b/src/lib/components/prompt/PromptEditor.svelte
@@ -70,7 +70,9 @@
 >
 	<div class="relative min-h-24 grow overflow-y-auto rounded border shadow">
 		<textarea
-			class="relative h-full min-h-24 w-full border-none bg-white py-2 pl-2 pr-6 text-sm outline-none selection:bg-transparent"
+			class="relative h-full min-h-24 w-full border-none bg-white py-2 pl-2 pr-6 text-sm outline-none {selectedSpan
+				? 'selection:bg-transparent'
+				: ''}"
 			bind:this={promptEditor}
 			bind:value={editedPrompt.prompt}
 			use:autosize
@@ -89,6 +91,7 @@
 			{hoveredSuggestion}
 			{suggestionApplied}
 			{editedPrompt}
+			{promptWasEdited}
 			bind:selectedSpan
 			{suggestions}
 		/>

--- a/src/lib/components/prompt/PromptSuggestion.svelte
+++ b/src/lib/components/prompt/PromptSuggestion.svelte
@@ -6,6 +6,7 @@
 	import type { Tables } from '$lib/supabase';
 	import { EditorType, RequiredInputType } from '$lib/types';
 	import { Check, Coins, FlaskConical, Lightbulb, ShieldX } from 'lucide-svelte';
+	import { fade } from 'svelte/transition';
 
 	let {
 		suggestion,
@@ -55,6 +56,7 @@
 	class="flex w-full flex-col justify-between rounded-br rounded-tr border border-l-4 px-3 py-2 text-left {disabled
 		? 'border-l-gray-active'
 		: borderMap[suggestion.type]}"
+	transition:fade={{ duration: 200 }}
 >
 	<div class="flex flex-col">
 		<div class="flex items-center gap-2">

--- a/src/lib/components/prompt/PromptSuggestion.svelte
+++ b/src/lib/components/prompt/PromptSuggestion.svelte
@@ -38,6 +38,7 @@
 
 	async function accept() {
 		applyingSuggestion = true;
+		selectedSpan = undefined;
 		if (suggestion.type === 'DATA') {
 			dataGenerationOptions.instruction = suggestion.description
 				.split(':')

--- a/src/lib/components/prompt/PromptSuggestion.svelte
+++ b/src/lib/components/prompt/PromptSuggestion.svelte
@@ -38,7 +38,6 @@
 
 	async function accept() {
 		applyingSuggestion = true;
-		selectedSpan = undefined;
 		if (suggestion.type === 'DATA') {
 			dataGenerationOptions.instruction = suggestion.description
 				.split(':')
@@ -65,6 +64,7 @@
 			);
 			editPrompt(changedPrompt, suggestion.id);
 		}
+		selectedSpan = undefined;
 		applyingSuggestion = false;
 	}
 </script>

--- a/src/lib/components/prompt/PromptSuggestion.svelte
+++ b/src/lib/components/prompt/PromptSuggestion.svelte
@@ -13,6 +13,7 @@
 		prompt,
 		editPrompt,
 		dismissSuggestion,
+		selectedSpan,
 		applied = false,
 		disabled = false
 	} = $props<{
@@ -20,6 +21,7 @@
 		prompt: Tables<'prompts'>;
 		editPrompt: (newPrompt: Tables<'prompts'>, suggestionId: number) => void;
 		dismissSuggestion: (suggestion: Tables<'suggestions'>) => void;
+		selectedSpan: { start: number; end: number } | undefined;
 		applied?: boolean;
 		disabled?: boolean;
 	}>();
@@ -45,7 +47,21 @@
 			dataGenerationOptions.show = true;
 			dismissSuggestion(suggestion);
 		} else {
-			const changedPrompt = await acceptSuggestion(suggestion, prompt, userInput);
+			// Get only the spans that are within the selected span
+			const targetSpans =
+				suggestion.target_spans && selectedSpan
+					? suggestion.target_spans.filter(
+							(s) => s[0] >= selectedSpan!.start && s[1] <= selectedSpan!.end
+						)
+					: suggestion.target_spans;
+			const changedPrompt = await acceptSuggestion(
+				{
+					...suggestion,
+					target_spans: targetSpans
+				},
+				prompt,
+				userInput
+			);
 			editPrompt(changedPrompt, suggestion.id);
 		}
 		applyingSuggestion = false;

--- a/src/lib/components/prompt/PromptSuggestions.svelte
+++ b/src/lib/components/prompt/PromptSuggestions.svelte
@@ -3,6 +3,7 @@
 	import Spinner from '$lib/components/ui/Spinner.svelte';
 	import type { Tables } from '$lib/supabase';
 	import { tooltip } from '$lib/tooltip.svelte';
+	import { filterSuggestions } from '$lib/util';
 	import { RefreshCw } from 'lucide-svelte';
 	import { fade } from 'svelte/transition';
 	import PromptSuggestion from './PromptSuggestion.svelte';
@@ -45,19 +46,6 @@
 			})
 		});
 	}
-
-	function filterSuggestions(
-		suggestions: Tables<'suggestions'>[] | undefined,
-		selectedSpan: { start: number; end: number } | undefined
-	): Tables<'suggestions'>[] | undefined {
-		if (suggestions === undefined) return undefined;
-		if (selectedSpan) {
-			return suggestions.filter((s) =>
-				s.target_spans?.some((s) => s[0] >= selectedSpan.start && s[1] <= selectedSpan.end)
-			);
-		}
-		return suggestions;
-	}
 </script>
 
 <div
@@ -93,7 +81,14 @@
 			{:else if suggestionApplied > -1}
 				{@const suggestion = filteredSuggestions.find((s) => s.id === suggestionApplied)}
 				{#if suggestion !== undefined}
-					<PromptSuggestion {prompt} {suggestion} {dismissSuggestion} {editPrompt} applied />
+					<PromptSuggestion
+						{selectedSpan}
+						{prompt}
+						{suggestion}
+						{dismissSuggestion}
+						{editPrompt}
+						applied
+					/>
 				{/if}
 				{#each filteredSuggestions.filter((s) => s.id !== suggestionApplied) as suggestion (suggestion.id)}
 					<div
@@ -101,7 +96,14 @@
 							text: 'To apply another suggestion, either save or revert the current changes.'
 						}}
 					>
-						<PromptSuggestion {prompt} {suggestion} {dismissSuggestion} {editPrompt} disabled />
+						<PromptSuggestion
+							{selectedSpan}
+							{prompt}
+							{suggestion}
+							{dismissSuggestion}
+							{editPrompt}
+							disabled
+						/>
 					</div>
 				{/each}
 			{:else if promptWasEdited}
@@ -111,7 +113,14 @@
 							text: 'To apply a suggestion, either save or revert the current changes.'
 						}}
 					>
-						<PromptSuggestion {prompt} {suggestion} {dismissSuggestion} {editPrompt} disabled />
+						<PromptSuggestion
+							{selectedSpan}
+							{prompt}
+							{suggestion}
+							{dismissSuggestion}
+							{editPrompt}
+							disabled
+						/>
 					</div>
 				{/each}
 			{:else}
@@ -125,7 +134,13 @@
 						tabindex="0"
 						class="flex"
 					>
-						<PromptSuggestion {prompt} {suggestion} {dismissSuggestion} {editPrompt} />
+						<PromptSuggestion
+							{selectedSpan}
+							{prompt}
+							{suggestion}
+							{dismissSuggestion}
+							{editPrompt}
+						/>
 					</div>
 				{/each}
 			{/if}

--- a/src/lib/components/prompt/PromptSuggestions.svelte
+++ b/src/lib/components/prompt/PromptSuggestions.svelte
@@ -6,6 +6,7 @@
 	import { RefreshCw } from 'lucide-svelte';
 	import { fade } from 'svelte/transition';
 	import PromptSuggestion from './PromptSuggestion.svelte';
+	import RewriteBox from './RewriteBox.svelte';
 
 	let {
 		prompt,
@@ -14,6 +15,7 @@
 		editPrompt,
 		suggestions,
 		suggestionApplied,
+		selectedSpan,
 		toplevel = false
 	} = $props<{
 		prompt: Tables<'prompts'>;
@@ -22,6 +24,7 @@
 		editPrompt: (newPrompt: Tables<'prompts'>, suggestionId: number) => void;
 		suggestions: Promise<Tables<'suggestions'>[] | undefined>;
 		suggestionApplied: number;
+		selectedSpan: { start: number; end: number } | undefined;
 		toplevel?: boolean;
 	}>();
 
@@ -65,6 +68,9 @@
 		</button>
 	</div>
 	<div class="flex flex-col gap-4 overflow-auto">
+		{#if selectedSpan}
+			<RewriteBox bind:selectedSpan {prompt} {editPrompt} />
+		{/if}
 		{#await suggestions then suggestions}
 			{#if suggestions === undefined || suggestions.length === 0}
 				No suggestions

--- a/src/lib/components/prompt/PromptSuggestions.svelte
+++ b/src/lib/components/prompt/PromptSuggestions.svelte
@@ -69,11 +69,11 @@
 		</button>
 	</div>
 	<div class="flex flex-col gap-4 overflow-auto">
-		{#if selectedSpan}
-			<RewriteBox bind:selectedSpan {prompt} {editPrompt} />
-		{/if}
 		{#await suggestions then suggestions}
-			{@const filteredSuggestions = filterSuggestions(suggestions, selectedSpan)}
+			{@const filteredSuggestions =
+				promptWasEdited && selectedSpan !== undefined
+					? []
+					: filterSuggestions(suggestions, selectedSpan)}
 			{#if filteredSuggestions === undefined || filteredSuggestions.length === 0}
 				{#if selectedSpan === undefined}
 					No suggestions
@@ -82,7 +82,7 @@
 				{@const suggestion = filteredSuggestions.find((s) => s.id === suggestionApplied)}
 				{#if suggestion !== undefined}
 					<PromptSuggestion
-						{selectedSpan}
+						bind:selectedSpan
 						{prompt}
 						{suggestion}
 						{dismissSuggestion}
@@ -97,7 +97,7 @@
 						}}
 					>
 						<PromptSuggestion
-							{selectedSpan}
+							bind:selectedSpan
 							{prompt}
 							{suggestion}
 							{dismissSuggestion}
@@ -114,7 +114,7 @@
 						}}
 					>
 						<PromptSuggestion
-							{selectedSpan}
+							bind:selectedSpan
 							{prompt}
 							{suggestion}
 							{dismissSuggestion}
@@ -135,7 +135,7 @@
 						class="flex"
 					>
 						<PromptSuggestion
-							{selectedSpan}
+							bind:selectedSpan
 							{prompt}
 							{suggestion}
 							{dismissSuggestion}
@@ -145,5 +145,8 @@
 				{/each}
 			{/if}
 		{/await}
+		{#if selectedSpan}
+			<RewriteBox bind:selectedSpan {prompt} {editPrompt} />
+		{/if}
 	</div>
 </div>

--- a/src/lib/components/prompt/RewriteBox.svelte
+++ b/src/lib/components/prompt/RewriteBox.svelte
@@ -3,6 +3,7 @@
 	import Button from '$lib/components/ui/Button.svelte';
 	import Spinner from '$lib/components/ui/Spinner.svelte';
 	import type { Tables } from '$lib/supabase';
+	import { Edit3 } from 'lucide-svelte';
 	import { fade } from 'svelte/transition';
 
 	let { selectedSpan, prompt, editPrompt } = $props<{
@@ -33,25 +34,31 @@
 </script>
 
 <button
-	class="absolute left-full top-0 z-50 w-[400px] cursor-default"
+	class="cursor-default"
 	transition:fade={{ duration: 200 }}
 	onmouseup={(e) => e.stopPropagation()}
 >
 	<div
-		class="ml-2 flex flex-col items-start rounded-br rounded-tr border border-l-4 border-l-blue-500 bg-white p-4 shadow"
+		class="flex w-full flex-col justify-between rounded-br rounded-tr border border-l-4 border-l-blue-500 px-3 py-2 text-left"
 	>
-		<h3>Rewrite the selected text</h3>
-		<textarea
-			class="mt-2 w-full resize-none"
-			placeholder="describe how to rewrite the selected text"
-			bind:value={userInput}
-			onkeydown={(e) => {
-				if (e.key === 'Enter' && e.metaKey) {
-					e.preventDefault();
-					accept();
-				}
-			}}
-		/>
+		<div class="flex flex-col">
+			<div class="flex items-center gap-2">
+				<Edit3 class="h-5 w-5 text-blue-500" />
+				<h4>Rewrite the selected text</h4>
+			</div>
+			<p class="mt-1 text-sm text-gray-active">Let AI help you rewrite part of your prompt.</p>
+			<textarea
+				class="mt-2 w-full"
+				placeholder="describe how to rewrite the selected text"
+				bind:value={userInput}
+				onkeydown={(e) => {
+					if (e.key === 'Enter' && e.metaKey) {
+						e.preventDefault();
+						accept();
+					}
+				}}
+			/>
+		</div>
 		<div class="flex w-full items-center justify-end pt-2">
 			{#if applyingSuggestion}
 				<Spinner />

--- a/src/lib/components/prompt/RewriteBox.svelte
+++ b/src/lib/components/prompt/RewriteBox.svelte
@@ -44,7 +44,7 @@
 		<div class="flex flex-col">
 			<div class="flex items-center gap-2">
 				<Edit3 class="h-5 w-5 text-blue-500" />
-				<h4>Rewrite the selected text</h4>
+				<h4>Rewrite part of your prompt with AI</h4>
 			</div>
 			<p class="mt-1 text-sm text-gray-active">Let AI help you rewrite part of your prompt.</p>
 			<textarea

--- a/src/lib/components/prompt/SuggestionOverlay.svelte
+++ b/src/lib/components/prompt/SuggestionOverlay.svelte
@@ -1,29 +1,61 @@
 <script lang="ts">
 	import type { Tables } from '$lib/supabase';
+	import { filterSuggestions } from '$lib/util';
 	import * as diff from 'diff';
 	import { fade } from 'svelte/transition';
 
-	let { prompt, hoveredSuggestion, suggestionApplied, editedPrompt, selectedSpan } = $props<{
-		prompt: Tables<'prompts'>;
-		hoveredSuggestion: Tables<'suggestions'> | null;
-		suggestionApplied: number;
-		editedPrompt: Tables<'prompts'>;
-		selectedSpan: { start: number; end: number } | undefined;
-	}>();
+	let { prompt, hoveredSuggestion, suggestionApplied, editedPrompt, selectedSpan, suggestions } =
+		$props<{
+			prompt: Tables<'prompts'>;
+			hoveredSuggestion: Tables<'suggestions'> | null;
+			suggestionApplied: number;
+			editedPrompt: Tables<'prompts'>;
+			selectedSpan: { start: number; end: number } | undefined;
+			suggestions: Promise<Tables<'suggestions'>[] | undefined>;
+		}>();
+
+	function combineSpans(suggestions: Tables<'suggestions'>[]): number[][] {
+		// Combine overlapping spans.
+		const allSpans: number[][] = suggestions
+			.flatMap((suggestion) => suggestion.target_spans || [])
+			.sort((a, b) => a[0] - b[0]);
+
+		const combinedSpans: number[][] = [];
+		let currentSpan = allSpans[0];
+
+		for (let i = 1; i < allSpans.length; i++) {
+			if (allSpans[i][0] <= currentSpan[1]) {
+				currentSpan[1] = Math.max(currentSpan[1], allSpans[i][1]);
+			} else {
+				combinedSpans.push(currentSpan);
+				currentSpan = allSpans[i];
+			}
+		}
+
+		combinedSpans.push(currentSpan);
+		return combinedSpans;
+	}
 </script>
 
-<div
-	class="user-select-none pointer-events-none absolute left-0 top-0 h-full min-h-24 w-full whitespace-pre-line py-2 pl-2 pr-6 text-sm text-transparent"
-	aria-hidden="true"
-	transition:fade={{ duration: 200 }}
->
-	{#if selectedSpan}
+{#if selectedSpan}
+	<div
+		class="user-select-none pointer-events-none absolute left-0 top-0 h-full min-h-24 w-full whitespace-pre-line py-2 pl-2 pr-6 text-sm text-transparent"
+		aria-hidden="true"
+		transition:fade={{ duration: 200 }}
+	>
 		{editedPrompt.prompt.slice(0, selectedSpan.start)}
-		<span class="underline decoration-blue-600 decoration-2">
+		<span class="bg-blue-600 bg-opacity-20">
 			{editedPrompt.prompt.slice(selectedSpan.start, selectedSpan.end)}
 		</span>
 		{editedPrompt.prompt.slice(selectedSpan.end)}
-	{:else if suggestionApplied !== -1}
+	</div>
+{/if}
+<div
+	class="pointer-events-none absolute left-0 top-0 h-full min-h-24 w-full select-none whitespace-pre-line py-2 pl-2 pr-6 text-sm text-transparent"
+	aria-hidden="true"
+	transition:fade={{ duration: 200 }}
+>
+	{#if suggestionApplied !== -1}
 		{#each diff.diffWords(prompt.prompt, editedPrompt.prompt) as part}
 			{#if part.added}
 				<span class="bg-blue-600 opacity-30">{part.value}</span>
@@ -43,5 +75,31 @@
 				</span>
 			{/if}
 		{/each}
+	{:else}
+		{#await suggestions then suggestions}
+			{@const filteredSuggestions = filterSuggestions(suggestions, selectedSpan)}
+			{#if filteredSuggestions && filteredSuggestions.length > 0}
+				{@const combinedSpans = combineSpans(filteredSuggestions)}
+				{#if combinedSpans.length > 0}
+					{prompt.prompt.slice(0, combinedSpans[0][0])}
+					{#each combinedSpans as span, index}
+						<span
+							class="pointer-events-auto cursor-pointer underline decoration-red-500 decoration-2"
+							onclick={() => (selectedSpan = { start: span[0], end: span[1] })}
+							role="button"
+							tabindex="0"
+							onkeydown={() => {}}
+						>
+							{prompt.prompt.slice(span[0], span[1])}
+						</span>
+						{#if index === combinedSpans.length - 1}
+							{prompt.prompt.slice(span[1])}
+						{:else}
+							{prompt.prompt.slice(span[1], combinedSpans[index + 1][0])}
+						{/if}
+					{/each}
+				{/if}
+			{/if}
+		{/await}
 	{/if}
 </div>

--- a/src/lib/components/prompt/SuggestionOverlay.svelte
+++ b/src/lib/components/prompt/SuggestionOverlay.svelte
@@ -61,61 +61,57 @@
 			{editedPrompt.prompt.slice(selectedSpan.end)}
 		</span>
 	</div>
-{:else if !promptWasEdited}
-	<div
-		class="pointer-events-none absolute left-0 top-0 h-full min-h-24 w-full select-none whitespace-pre-line py-2 pl-2 pr-6 text-sm text-transparent"
-		aria-hidden="true"
-		transition:fade={{ duration: 200 }}
-	>
-		{#if suggestionApplied !== -1}
-			{#each diff.diffWords(prompt.prompt, editedPrompt.prompt) as part}
-				{#if part.added}
-					<span class="bg-blue-600 opacity-30">{part.value}</span>
-				{:else if !part.removed}
-					{part.value}
-				{/if}
-			{/each}
-		{:else if hoveredSuggestion && hoveredSuggestion.target_spans}
-			{#each hoveredSuggestion.target_spans as span, index}
-				{prompt.prompt.slice(
-					index === 0 ? 0 : hoveredSuggestion.target_spans[index - 1][1],
-					span[0]
-				)}
-				<span class="underline decoration-red-500 decoration-2">
-					{prompt.prompt.slice(span[0], span[1])}
-				</span>
-				{#if index === hoveredSuggestion.target_spans.length - 1}
-					<span>
-						{prompt.prompt.slice(span[1])}
-					</span>
-				{/if}
-			{/each}
-		{:else}
-			{#await suggestions then suggestions}
-				{@const filteredSuggestions = filterSuggestions(suggestions, selectedSpan)}
-				{#if filteredSuggestions && filteredSuggestions.length > 0}
-					{@const combinedSpans = combineSpans(filteredSuggestions)}
-					{#if combinedSpans.length > 0}
-						{prompt.prompt.slice(0, combinedSpans[0][0])}
-						{#each combinedSpans as span, index}
-							<span
-								class="pointer-events-auto cursor-pointer underline decoration-red-500 decoration-2"
-								onclick={() => (selectedSpan = { start: span[0], end: span[1] })}
-								role="button"
-								tabindex="0"
-								onkeydown={() => {}}
-							>
-								{prompt.prompt.slice(span[0], span[1])}
-							</span>
-							{#if index === combinedSpans.length - 1}
-								{prompt.prompt.slice(span[1])}
-							{:else}
-								{prompt.prompt.slice(span[1], combinedSpans[index + 1][0])}
-							{/if}
-						{/each}
-					{/if}
-				{/if}
-			{/await}
-		{/if}
-	</div>
 {/if}
+<div
+	class="pointer-events-none absolute left-0 top-0 h-full min-h-24 w-full select-none whitespace-pre-line py-2 pl-2 pr-6 text-sm text-transparent"
+	aria-hidden="true"
+	transition:fade={{ duration: 200 }}
+>
+	{#if suggestionApplied !== -1}
+		{#each diff.diffWords(prompt.prompt, editedPrompt.prompt) as part}
+			{#if part.added}
+				<span class="bg-blue-600 opacity-30">{part.value}</span>
+			{:else if !part.removed}
+				{part.value}
+			{/if}
+		{/each}
+	{:else if hoveredSuggestion && hoveredSuggestion.target_spans && !promptWasEdited}
+		{#each hoveredSuggestion.target_spans as span, index}
+			{prompt.prompt.slice(index === 0 ? 0 : hoveredSuggestion.target_spans[index - 1][1], span[0])}
+			<span class="underline decoration-red-500 decoration-2">
+				{prompt.prompt.slice(span[0], span[1])}
+			</span>
+			{#if index === hoveredSuggestion.target_spans.length - 1}
+				<span>
+					{prompt.prompt.slice(span[1])}
+				</span>
+			{/if}
+		{/each}
+	{:else if !promptWasEdited}
+		{#await suggestions then suggestions}
+			{@const filteredSuggestions = filterSuggestions(suggestions, selectedSpan)}
+			{#if filteredSuggestions && filteredSuggestions.length > 0}
+				{@const combinedSpans = combineSpans(filteredSuggestions)}
+				{#if combinedSpans.length > 0}
+					{prompt.prompt.slice(0, combinedSpans[0][0])}
+					{#each combinedSpans as span, index}
+						<span
+							class="pointer-events-auto cursor-pointer underline decoration-red-500 decoration-2"
+							onclick={() => (selectedSpan = { start: span[0], end: span[1] })}
+							role="button"
+							tabindex="0"
+							onkeydown={() => {}}
+						>
+							{prompt.prompt.slice(span[0], span[1])}
+						</span>
+						{#if index === combinedSpans.length - 1}
+							{prompt.prompt.slice(span[1])}
+						{:else}
+							{prompt.prompt.slice(span[1], combinedSpans[index + 1][0])}
+						{/if}
+					{/each}
+				{/if}
+			{/if}
+		{/await}
+	{/if}
+</div>

--- a/src/lib/components/prompt/SuggestionOverlay.svelte
+++ b/src/lib/components/prompt/SuggestionOverlay.svelte
@@ -4,15 +4,23 @@
 	import * as diff from 'diff';
 	import { fade } from 'svelte/transition';
 
-	let { prompt, hoveredSuggestion, suggestionApplied, editedPrompt, selectedSpan, suggestions } =
-		$props<{
-			prompt: Tables<'prompts'>;
-			hoveredSuggestion: Tables<'suggestions'> | null;
-			suggestionApplied: number;
-			editedPrompt: Tables<'prompts'>;
-			selectedSpan: { start: number; end: number } | undefined;
-			suggestions: Promise<Tables<'suggestions'>[] | undefined>;
-		}>();
+	let {
+		prompt,
+		hoveredSuggestion,
+		suggestionApplied,
+		editedPrompt,
+		selectedSpan,
+		suggestions,
+		promptWasEdited
+	} = $props<{
+		prompt: Tables<'prompts'>;
+		hoveredSuggestion: Tables<'suggestions'> | null;
+		suggestionApplied: number;
+		editedPrompt: Tables<'prompts'>;
+		selectedSpan: { start: number; end: number } | undefined;
+		suggestions: Promise<Tables<'suggestions'>[] | undefined>;
+		promptWasEdited: boolean;
+	}>();
 
 	function combineSpans(suggestions: Tables<'suggestions'>[]): number[][] {
 		// Combine overlapping spans.
@@ -39,67 +47,75 @@
 
 {#if selectedSpan}
 	<div
-		class="user-select-none pointer-events-none absolute left-0 top-0 h-full min-h-24 w-full whitespace-pre-line py-2 pl-2 pr-6 text-sm text-transparent"
+		class="user-select-none pointer-events-none absolute left-0 top-0 h-full min-h-24 w-full whitespace-pre-line py-2 pl-2 pr-6 text-[0px] text-transparent"
 		aria-hidden="true"
 		transition:fade={{ duration: 200 }}
 	>
-		{editedPrompt.prompt.slice(0, selectedSpan.start)}
-		<span class="bg-blue-600 bg-opacity-20">
+		<span class="text-sm">
+			{editedPrompt.prompt.slice(0, selectedSpan.start)}
+		</span>
+		<span class="bg-blue-600 bg-opacity-20 text-sm">
 			{editedPrompt.prompt.slice(selectedSpan.start, selectedSpan.end)}
 		</span>
-		{editedPrompt.prompt.slice(selectedSpan.end)}
+		<span class="text-sm">
+			{editedPrompt.prompt.slice(selectedSpan.end)}
+		</span>
+	</div>
+{:else if !promptWasEdited}
+	<div
+		class="pointer-events-none absolute left-0 top-0 h-full min-h-24 w-full select-none whitespace-pre-line py-2 pl-2 pr-6 text-sm text-transparent"
+		aria-hidden="true"
+		transition:fade={{ duration: 200 }}
+	>
+		{#if suggestionApplied !== -1}
+			{#each diff.diffWords(prompt.prompt, editedPrompt.prompt) as part}
+				{#if part.added}
+					<span class="bg-blue-600 opacity-30">{part.value}</span>
+				{:else if !part.removed}
+					{part.value}
+				{/if}
+			{/each}
+		{:else if hoveredSuggestion && hoveredSuggestion.target_spans}
+			{#each hoveredSuggestion.target_spans as span, index}
+				{prompt.prompt.slice(
+					index === 0 ? 0 : hoveredSuggestion.target_spans[index - 1][1],
+					span[0]
+				)}
+				<span class="underline decoration-red-500 decoration-2">
+					{prompt.prompt.slice(span[0], span[1])}
+				</span>
+				{#if index === hoveredSuggestion.target_spans.length - 1}
+					<span>
+						{prompt.prompt.slice(span[1])}
+					</span>
+				{/if}
+			{/each}
+		{:else}
+			{#await suggestions then suggestions}
+				{@const filteredSuggestions = filterSuggestions(suggestions, selectedSpan)}
+				{#if filteredSuggestions && filteredSuggestions.length > 0}
+					{@const combinedSpans = combineSpans(filteredSuggestions)}
+					{#if combinedSpans.length > 0}
+						{prompt.prompt.slice(0, combinedSpans[0][0])}
+						{#each combinedSpans as span, index}
+							<span
+								class="pointer-events-auto cursor-pointer underline decoration-red-500 decoration-2"
+								onclick={() => (selectedSpan = { start: span[0], end: span[1] })}
+								role="button"
+								tabindex="0"
+								onkeydown={() => {}}
+							>
+								{prompt.prompt.slice(span[0], span[1])}
+							</span>
+							{#if index === combinedSpans.length - 1}
+								{prompt.prompt.slice(span[1])}
+							{:else}
+								{prompt.prompt.slice(span[1], combinedSpans[index + 1][0])}
+							{/if}
+						{/each}
+					{/if}
+				{/if}
+			{/await}
+		{/if}
 	</div>
 {/if}
-<div
-	class="pointer-events-none absolute left-0 top-0 h-full min-h-24 w-full select-none whitespace-pre-line py-2 pl-2 pr-6 text-sm text-transparent"
-	aria-hidden="true"
-	transition:fade={{ duration: 200 }}
->
-	{#if suggestionApplied !== -1}
-		{#each diff.diffWords(prompt.prompt, editedPrompt.prompt) as part}
-			{#if part.added}
-				<span class="bg-blue-600 opacity-30">{part.value}</span>
-			{:else if !part.removed}
-				{part.value}
-			{/if}
-		{/each}
-	{:else if hoveredSuggestion && hoveredSuggestion.target_spans}
-		{#each hoveredSuggestion.target_spans as span, index}
-			{prompt.prompt.slice(index === 0 ? 0 : hoveredSuggestion.target_spans[index - 1][1], span[0])}
-			<span class="underline decoration-red-500 decoration-2">
-				{prompt.prompt.slice(span[0], span[1])}
-			</span>
-			{#if index === hoveredSuggestion.target_spans.length - 1}
-				<span>
-					{prompt.prompt.slice(span[1])}
-				</span>
-			{/if}
-		{/each}
-	{:else}
-		{#await suggestions then suggestions}
-			{@const filteredSuggestions = filterSuggestions(suggestions, selectedSpan)}
-			{#if filteredSuggestions && filteredSuggestions.length > 0}
-				{@const combinedSpans = combineSpans(filteredSuggestions)}
-				{#if combinedSpans.length > 0}
-					{prompt.prompt.slice(0, combinedSpans[0][0])}
-					{#each combinedSpans as span, index}
-						<span
-							class="pointer-events-auto cursor-pointer underline decoration-red-500 decoration-2"
-							onclick={() => (selectedSpan = { start: span[0], end: span[1] })}
-							role="button"
-							tabindex="0"
-							onkeydown={() => {}}
-						>
-							{prompt.prompt.slice(span[0], span[1])}
-						</span>
-						{#if index === combinedSpans.length - 1}
-							{prompt.prompt.slice(span[1])}
-						{:else}
-							{prompt.prompt.slice(span[1], combinedSpans[index + 1][0])}
-						{/if}
-					{/each}
-				{/if}
-			{/if}
-		{/await}
-	{/if}
-</div>

--- a/src/lib/components/views/PromptView.svelte
+++ b/src/lib/components/views/PromptView.svelte
@@ -31,6 +31,7 @@
 	}>();
 
 	let showOptions = $state(false);
+	let selectedSpan = $state<{ start: number; end: number } | undefined>(undefined);
 </script>
 
 <ViewParent {onclose}>
@@ -60,9 +61,9 @@
 				setPrompt();
 				onclose();
 			}}
-			{editPrompt}
 			bind:suggestionApplied
 			bind:editedPrompt
+			bind:selectedSpan
 		/>
 	</div>
 	<div class="flex h-full w-[450px] shrink-0 flex-col border-l px-6 py-4">
@@ -72,6 +73,7 @@
 				{editedPrompt}
 				{suggestionApplied}
 				bind:suggestions
+				bind:selectedSpan
 				{editPrompt}
 				setHoveredSuggestion={(suggestion) => (hoveredSuggestion = suggestion)}
 				toplevel={true}

--- a/src/lib/components/views/PromptView.svelte
+++ b/src/lib/components/views/PromptView.svelte
@@ -56,6 +56,7 @@
 		<PromptEditor
 			{prompt}
 			{hoveredSuggestion}
+			{suggestions}
 			promptMaximized={true}
 			setPrompt={() => {
 				setPrompt();

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,0 +1,14 @@
+import type { Tables } from './supabase';
+
+export function filterSuggestions(
+	suggestions: Tables<'suggestions'>[] | undefined,
+	selectedSpan: { start: number; end: number } | undefined
+): Tables<'suggestions'>[] | undefined {
+	if (suggestions === undefined) return undefined;
+	if (selectedSpan) {
+		return suggestions.filter((s) =>
+			s.target_spans?.some((s) => s[0] >= selectedSpan.start && s[1] <= selectedSpan.end)
+		);
+	}
+	return suggestions;
+}


### PR DESCRIPTION
fix EOT-54

* moves the selected edit suggestion down to all other suggestions
* always displays span underlines of edit suggestions
* makes span underlines clickable which sets the selected span to that area
* filters suggestions so that only those with target spans within the selected span are visible
* when clicking apply for a suggestion, only change what is in the selected span